### PR TITLE
removed outdated dependencies from pom, removed code that didn't compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 target/
 .idea/
 /src/main/resources/wolfbeacon-42-a514a0a7c765.p12
+/src/main/webapp/static/.fuse_hidden0000028d00000001

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
         <maven.version>3.1.0</maven.version>
-        <pac4j.version>1.9.0-SNAPSHOT</pac4j.version>
+        <pac4j.version>1.9.0</pac4j.version>
         <hibernate.version>5.1.0.Final</hibernate.version>
         <mysql.connector.version>6.0.2</mysql.connector.version>
         <jackson.version>2.7.4</jackson.version>
@@ -404,6 +404,13 @@
                     <webApp>
                         <contextPath>/</contextPath>
                     </webApp>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/io/wolfbeacon/server/security/gitkit/GitKitCookieExtractor.java
+++ b/src/main/java/io/wolfbeacon/server/security/gitkit/GitKitCookieExtractor.java
@@ -4,7 +4,6 @@ import org.pac4j.core.context.Cookie;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.credentials.TokenCredentials;
 import org.pac4j.core.credentials.extractor.CredentialsExtractor;
-import org.pac4j.core.exception.RequiresHttpAction;
 import org.pac4j.core.util.CommonHelper;
 
 import javax.validation.constraints.NotNull;
@@ -23,7 +22,7 @@ class GitKitCookieExtractor implements CredentialsExtractor<TokenCredentials> {
     }
 
     @Override
-    public TokenCredentials extract(final WebContext context) throws RequiresHttpAction {
+    public TokenCredentials extract(final WebContext context) {
         Collection<Cookie> cookies = context.getRequestCookies();
         if (cookies == null) {
             return null;

--- a/src/main/java/io/wolfbeacon/server/security/gitkit/GitkitAuthenticator.java
+++ b/src/main/java/io/wolfbeacon/server/security/gitkit/GitkitAuthenticator.java
@@ -4,7 +4,6 @@ import io.wolfbeacon.server.service.GitKitIdentityService;
 import org.pac4j.core.credentials.TokenCredentials;
 import org.pac4j.core.credentials.authenticator.TokenAuthenticator;
 import org.pac4j.core.exception.CredentialsException;
-import org.pac4j.core.exception.RequiresHttpAction;
 
 /**
  * Created by Aaron on 05/05/2016.
@@ -18,7 +17,7 @@ public class GitkitAuthenticator implements TokenAuthenticator {
     }
 
     @Override
-    public void validate(TokenCredentials credentials) throws RequiresHttpAction {
+    public void validate(TokenCredentials credentials) {
         GitKitProfile profile;
         try {
             profile = gitKitIdentityService.getGitKitProfile(credentials.getToken(), false);

--- a/src/main/java/io/wolfbeacon/server/service/GitKitIdentityService.java
+++ b/src/main/java/io/wolfbeacon/server/service/GitKitIdentityService.java
@@ -40,8 +40,16 @@ public class GitKitIdentityService {
 
     {
         try {
-            GITKIT_CLIENT = GitkitClient.createFromJson(getClass().getClassLoader()
-                    .getResource("gitkit-server-config.json").getPath().substring(1));
+            String os = System.getProperty("os.name").toLowerCase();
+            System.out.println(os);
+            if (os.indexOf("win") > 0) {
+                //substring(1) will return an Exception on Linux while running. The complete path is required (else condition)
+                GITKIT_CLIENT = GitkitClient.createFromJson(getClass().getClassLoader()
+                        .getResource("gitkit-server-config.json").getPath().substring(1));
+            } else {
+                GITKIT_CLIENT = GitkitClient.createFromJson(getClass().getClassLoader()
+                        .getResource("gitkit-server-config.json").getPath());
+            }
         } catch (GitkitClientException | IOException e) {
             e.printStackTrace();
         }

--- a/src/main/java/io/wolfbeacon/server/web/RequiresAuthenticationInterceptor.java
+++ b/src/main/java/io/wolfbeacon/server/web/RequiresAuthenticationInterceptor.java
@@ -15,7 +15,6 @@ import org.pac4j.core.context.J2EContext;
 import org.pac4j.core.context.Pac4jConstants;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.credentials.Credentials;
-import org.pac4j.core.exception.RequiresHttpAction;
 import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.core.profile.ProfileManager;
 import org.pac4j.core.profile.UserProfile;
@@ -90,8 +89,8 @@ public class RequiresAuthenticationInterceptor extends HandlerInterceptorAdapter
                     try {
                         credentials = currentClient.getCredentials(context);
                         logger.debug("credentials: {}", credentials);
-                    } catch (final RequiresHttpAction e) {
-                        logger.debug("extra HTTP action required: {}", e.getCode());
+                    } catch (final Exception e) {
+                        logger.debug("extra HTTP action required: {}", e.getCause());
                         return false;
                     }
                     profile = currentClient.getUserProfile(credentials, context);
@@ -152,8 +151,8 @@ public class RequiresAuthenticationInterceptor extends HandlerInterceptorAdapter
         try {
             final IndirectClient currentClient = (IndirectClient) currentClients.get(0);
             currentClient.redirect(context);
-        } catch (final RequiresHttpAction e) {
-            logger.debug("extra HTTP action required: {}", e.getCode());
+        } catch (final Exception e) {
+            logger.debug("extra HTTP action required: {}", e.getCause());
         }
     }
 


### PR DESCRIPTION
All the code i've removed is the stuff that doesn't compile. `org.pac4j.core.exception.RequiresHttpAction` isn't available in any recent version of _pac4j_ and the _1.9.0-SNAPSHOT_ repository isn't available anywhere online.

It's probably working for you since you have it cached for a long time. 

Also, you don't have the `web.xml` which made the build fail. I had to add lines 409-415. See `<failOnMissingWebXml>false</failOnMissingWebXml>`

Have a look and get back to me

cc @ralph-dev @aerovulpe 
